### PR TITLE
Add an option to override base model path

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ You can use the following command for launching a CLI interface:
 ```bash
 CUDA_VISIBLE_DEVICES=0 python -m medusa.inference.cli --model [path of medusa model]
 ```
-You can also pass `--load-in-8bit` or `--load-in-4bit` to load the base model in quantized format.
+You can also pass `--load-in-8bit` or `--load-in-4bit` to load the base model in quantized format. If you download the base model elsewhere, you may override base model name or path with `--base-model  [path of base model]`.
 
 ### Training
 For training, please install:

--- a/medusa/inference/cli.py
+++ b/medusa/inference/cli.py
@@ -36,6 +36,7 @@ def main(args):
     try:
         model = MedusaModel.from_pretrained(
             args.model,
+            args.base_model,
             torch_dtype=torch.float16,
             low_cpu_mem_usage=True,
             device_map="auto",
@@ -185,6 +186,7 @@ def main(args):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--model", type=str, required=True, help="Model name or path.")
+    parser.add_argument("--base-model", type=str, default=None, help="Base model name or path.")
     parser.add_argument(
         "--load-in-8bit", action="store_true", help="Use 8-bit quantization"
     )

--- a/medusa/model/medusa_model.py
+++ b/medusa/model/medusa_model.py
@@ -110,6 +110,7 @@ class MedusaModel(nn.Module):
     def from_pretrained(
         cls,
         medusa_head_name_or_path,
+        base_model=None,
         **kwargs,
     ):
         """
@@ -121,6 +122,10 @@ class MedusaModel(nn.Module):
             MedusaModel: A MedusaModel instance loaded from the given path.
         """
         medusa_config = MedusaConfig.from_pretrained(medusa_head_name_or_path)
+        if base_model:
+            print("Overriding base model as:", base_model)
+            medusa_config.base_model_name_or_path = base_model
+            
         base_model = KVLlamaForCausalLM.from_pretrained(
             medusa_config.base_model_name_or_path, **kwargs
         )

--- a/medusa/train/train.py
+++ b/medusa/train/train.py
@@ -345,6 +345,7 @@ def train():
         model,
         medusa_num_heads=training_args.medusa_num_heads,
         medusa_num_layers=training_args.medusa_num_layers,
+        base_model_name_or_path=model_args.model_name_or_path,
     )
 
     # Format output dir


### PR DESCRIPTION
I think many used to download the base model separately instead of using the huggingface cache. So an option in the argument parser to override base model path is added.

Also, `model_name_or_path` in `train.py` is not passed to constructor `MedusaModel`. I added it as a keyword argument to support local base model.