### PR TITLE
train_legacy.py: try to fix indices bug in preprocess.

### DIFF
--- a/medusa/train/train_legacy.py
+++ b/medusa/train/train_legacy.py
@@ -207,7 +207,7 @@ def preprocess(
                 stop = start + len(content)
                 indices= []
                 for tok_index, (tok_start, tok_stop) in enumerate(encoding.offset_mapping[conv_index]):
-                    if tok_stop >= start or tok_start < tok_stop:
+                    if tok_stop >= start and tok_start < stop:
                         indices.append(tok_index)
                 target[indices] = encoding.input_ids[conv_index][indices]
 


### PR DESCRIPTION
This seems a bug, also [reported by @xiezipeng-ML](https://github.com/FasterDecoding/Medusa/issues/101). Please review.