### PR TITLE
Fix sharing of resblock layers (from Liger-Kernel#269)

### DIFF
--- a/medusa/model/medusa_model.py
+++ b/medusa/model/medusa_model.py
@@ -111,7 +111,7 @@ class MedusaModelABC(nn.Module):
         self.medusa_head = nn.ModuleList(
             [
                 nn.Sequential(
-                    *([ResBlock(self.hidden_size)] * medusa_num_layers),
+                    *([ResBlock(self.hidden_size) for _ in range(medusa_num_layers)]),
                     nn.Linear(self.hidden_size, self.vocab_size, bias=False),
                 )
                 for _ in range(medusa_num_heads)


### PR DESCRIPTION
When using multiple residual block in medusa MLP heads, parameters are wrongly shared.

This was already reported in Hydra and already fixed in the Liger-Kernel repository
https://github.com/zankner/Hydra/issues/8
https://github.com/linkedin/Liger-Kernel/pull/269

